### PR TITLE
Fixed implementation of pytorch cuda device

### DIFF
--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -312,7 +312,7 @@ def main():
 
     y_pred, test_pids = start_sleep_net(
         master_acc, master_npids, args.outdir,
-        args.model_weight_path, local_repo_path=args.local_repo_path)
+        args.model_weight_path, local_repo_path=args.local_repo_path, device_id= args.pytorch_device)
     sleepnet_output = binary_y
 
     for block_id in range(len(all_sleep_wins_df)):

--- a/src/asleep/sleepnet.py
+++ b/src/asleep/sleepnet.py
@@ -95,10 +95,12 @@ def setup_dataset(X, pid, cfg, is_train=False):
 
 
 def config_device(cfg):
-    if cfg.gpu != -1:
-        my_device = "cuda:" + str(cfg.gpu)
+    if cfg.gpu != 'cpu':
+        my_device = str(cfg.gpu)
+        print ("pytorch device: "+my_device)
     else:
         my_device = "cpu"
+        print ("pytorch device defaulting to 'cpu'")
     return my_device
 
 
@@ -198,7 +200,7 @@ def sleepnet_inference(X, pid, weight_path, cfg, local_repo_path=""):
     return aligned_y_pred, test_pid
 
 
-def start_sleep_net(X, pid, data_root, weight_path, device_id=-1, local_repo_path=""):
+def start_sleep_net(X, pid, data_root, weight_path, device_id='cpu', local_repo_path=""):
     initialize(config_path="conf")
     cfg = compose(
         "config_eval",


### PR DESCRIPTION
We discovered the pytorch_device argument of get_sleep was not being passed on to sleepnet and hence never used. 

We also fixed the sleepnet code to correctly implement the use of a cuda device in pytorch and added a printed message that indicates the device being used, either the default 'cpu' or the cuda device input in the get_sleep call.