### PR TITLE
Fix index error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The key features of this package are as follows:
 
 
 # Dependencies
-- Python 3.8+
+- Python 3.8
 - Java 8 (1.8.0) or greater
 
 Check with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "asleep"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.4.5"  # Required
+version = "0.4.6"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -262,7 +262,7 @@ def main():
         help="Min wear time in hours to be eligible for summary statistics "
              "computation. The sleepnet paper uses 22",
         type=int,
-        default=0)
+        default=22)
     parser.add_argument(
         "--time_shift",
         type=str,

--- a/src/asleep/sleep_windows.py
+++ b/src/asleep/sleep_windows.py
@@ -98,6 +98,7 @@ def find_sleep_windows(sleep_blocks):
             if current_start_master_idx != -1:
                 all_sleep_blocks.append(
                     [current_start_master_idx, current_end_master_idx])
+                current_start_master_idx = -1
             continue
         pre_class = win[CLASS_POS]
 

--- a/src/asleep/summary.py
+++ b/src/asleep/summary.py
@@ -88,7 +88,7 @@ def generate_sleep_parameters(
         start_t = row['start']
         end_t = row['end']
 
-        time_filter = (times >= start_t) & (times < end_t)
+        time_filter = (times >= start_t) & (times <= end_t)
         current_day_y_pred = predictions_df['raw_label'][time_filter].values
         current_day_times = times[time_filter]
 


### PR DESCRIPTION
Resolves #42 

Two problems that cause this issue: 
* There were duplicate sleep block row when there is only one row within one day 
* When the sleep block has the same start and end time, the indexing operation cannot do filtering. Made the filtering operation more robust.
* Finally set the default min-wear time to be 22h per day as this is the default behaviour for sleepnet paper.

Will merge after local tests have completed. 


