### PR TITLE
Fix boundary condition for start date after noon. Thanks @BernieVA

### DIFF
--- a/src/asleep/sleep_windows.py
+++ b/src/asleep/sleep_windows.py
@@ -272,7 +272,10 @@ def get_day_intervals(start_date, end_date, date_format):
     my_day_end = pd.to_datetime(day_end_str, format=date_format)
     my_day_start = start_date.replace(
         hour=12, minute=0, second=0, microsecond=0)
-    my_day_start = my_day_start - timedelta(hours=24)
+
+    # if the start date is before 12:00 noon, then the interval start is 24 hours prior
+    if start_date.hour < 12:
+        my_day_start = my_day_start - timedelta(hours=24)
 
     while my_day_end < end_date:
         my_day_end = my_day_start + timedelta(hours=23, minutes=59, seconds=59)


### PR DESCRIPTION
When the start time on the first day is after noon, the first interval will be empty, as the current implementation moves the internal start to 24 hours prior.

This fix makes sure that when this happens, the first day should start from the same day.

Test plan:
```
python asleep/get_sleep.py ../data/sample.cwa
```

Output:
```
Total sample count : 7200
12it [03:46, 18.86s/it]
Save predictions to outputs/sample/y_pred.npy
Save prediction probs to outputs/sample/pred_prob.npy
Time used 227.81667113304138
predictions_df shape: (16841, 4)
                     time sleep_wake sleep_stage  raw_label
0 2014-05-07 13:29:50.430       wake        wake          0
1 2014-05-07 13:30:20.430       wake        wake          0
2 2014-05-07 13:30:50.430       wake        wake          0
3 2014-05-07 13:31:20.430       wake        wake          0
4 2014-05-07 13:31:50.430       wake        wake          0
Predictions saved to: outputs/sample/predictions.csv
                    start                           end      interval_start        interval_end  wear_duration_H  is_longest_block
0 2014-05-07 20:08:20.430 2014-05-07 20:55:50.430000000 2014-05-07 12:00:00 2014-05-08 11:59:59        22.508333             False
1 2014-05-07 21:48:50.430 2014-05-08 08:44:20.430000000 2014-05-07 12:00:00 2014-05-08 11:59:59        22.508333              True
2 2014-05-08 17:06:20.430 2014-05-08 17:59:20.430000000 2014-05-08 12:00:00 2014-05-09 11:59:59        24.000000             False
3 2014-05-09 00:38:20.430 2014-05-09 09:24:50.429999999 2014-05-08 12:00:00 2014-05-09 11:59:59        24.000000              True
4 2014-05-09 19:33:50.430 2014-05-09 20:09:20.430000000 2014-05-09 12:00:00 2014-05-10 11:59:59        24.000000             False
Sleep block saved to: outputs/sample/sleep_block.csv
Summary saved to: outputs/sample/summary.json
```