### PR TITLE
fix: do not delete info.json when passing --remove_intermediate_files

### DIFF
--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -321,7 +321,6 @@ def main():
         raw_data_path, info_data_path, resample_hz, args)
     if args.remove_intermediate_files:
         os.remove(raw_data_path)
-        os.remove(info_data_path)
 
     # 1.1 Transform data into a usable format for inference
     data2model, times, non_wear = transform_data2model_input(


### PR DESCRIPTION
Skip deletion of info.json file when using `--remove_intermediate_files` flag