### PR TITLE
feat: include file path in collated JSON data in collate_outputs.py

### DIFF
--- a/src/asleep/collate_outputs.py
+++ b/src/asleep/collate_outputs.py
@@ -50,7 +50,9 @@ def collate_jsons(file_list, outfile, overwrite=True):
     df = []
     for file in tqdm(file_list):
         with open(file, 'r') as f:
-            df.append(json.load(f, object_pairs_hook=OrderedDict))
+            j = json.load(f, object_pairs_hook=OrderedDict)
+            j['filepath'] = file
+            df.append(j)
     df = pd.DataFrame.from_dict(df)  # merge to a dataframe
     df = df.applymap(convert_ordereddict)  # convert any OrderedDict cell values to regular dict
     df.to_csv(outfile, index=False)


### PR DESCRIPTION
This pull request includes a change to the `collate_jsons` function in the `src/asleep/collate_outputs.py` file. It involes adding the file path to each JSON object before appending it to the list, which ensures that the source of each JSON object is tracked.

Enhancements to JSON collation:

* [`src/asleep/collate_outputs.py`](diffhunk://#diff-ceec8c297f0c28f82e484f4d54520e75c6aa58d1bc4866400aab341e8c5df8dfL53-R55): Modified the `collate_jsons` function to add the file path to each JSON object before appending it to the list. This change helps in tracking the source of each JSON object.