### PR TITLE
feat: add support for collating summary.json files in collate_outputs.py

### DIFF
--- a/src/asleep/collate_outputs.py
+++ b/src/asleep/collate_outputs.py
@@ -21,21 +21,29 @@ def collate_outputs(
     print("Searching files...")
 
     info_files = []
+    summary_files = []
 
     # Iterate through the files and append to the appropriate list based on the suffix
     for file in Path(results_dir).rglob('*'):
         if file.is_file():
             if file.name.endswith("info.json"):
                 info_files.append(file)
+            if file.name.endswith("summary.json"):
+                summary_files.append(file)
 
     collated_results_dir = Path(collated_results_dir)
     collated_results_dir.mkdir(parents=True, exist_ok=True)
 
-    # Collate Info.json files
-    print(f"Collating {len(info_files)} Info files...")
+    # Collate info.json files
+    print(f"Collating {len(info_files)} info files...")
     outfile = collated_results_dir / "info.csv.gz"
     collate_jsons(info_files, outfile)
     print('Collated info CSV written to', outfile)
+    # Collate summary.json files
+    print(f"Collating {len(summary_files)} summary files...")
+    outfile = collated_results_dir / "summary.csv.gz"
+    collate_jsons(summary_files, outfile)
+    print('Collated summary CSV written to', outfile)
 
     return
 


### PR DESCRIPTION
This pull request includes changes to the `collate_outputs` function in the `src/asleep/collate_outputs.py` file to also collate summary.json files.

* [`src/asleep/collate_outputs.py`](diffhunk://#diff-ceec8c297f0c28f82e484f4d54520e75c6aa58d1bc4866400aab341e8c5df8dfR24-R47): Changes to collate `summary.json` files into a `summary.csv.gz` output file.
* [`src/asleep/collate_outputs.py`](diffhunk://#diff-ceec8c297f0c28f82e484f4d54520e75c6aa58d1bc4866400aab341e8c5df8dfR24-R47): Updated the print statements for collating `info.json` files to use lowercase for consistency.