### PR TITLE
allowing to skip sleepnet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9']
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout

--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -237,7 +237,7 @@ def get_sleep_windows(data2model, times, non_wear, args):
         master_npids
 
 
-def download_models(force_download=False, include_sleepnet = True):
+def download_models(force_download=False):
     """Download all required model files without processing any data."""
     import asleep.sslmodel as sslmodel
 
@@ -261,13 +261,12 @@ def download_models(force_download=False, include_sleepnet = True):
     # 3. asleep repo + SleepNet CNN-LSTM weights via torch.hub
     #    torch.hub.set_dir was set in step 2, so repo + weights land in torch_hub_cache/
     #    Parameters must match the pretrained weights (config_eval: cnn_lstm_eval + deployment)
-    if include_sleepnet:
-        print("Caching SleepNet repository and weights...")
-        torch.hub.load(
-            'OxWearables/asleep', 'sleepnet',
-            num_classes=5, lstm_nn_size=1024, lstm_layer=2,
-            dropout_p=0, bi_lstm=True,
-            trust_repo=True)
+    print("Caching SleepNet repository and weights...")
+    torch.hub.load(
+        'OxWearables/asleep', 'sleepnet',
+        num_classes=5, lstm_nn_size=1024, lstm_layer=2,
+        dropout_p=0, bi_lstm=True,
+        trust_repo=True)
 
     print("All models downloaded successfully.")
 

--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -237,7 +237,7 @@ def get_sleep_windows(data2model, times, non_wear, args):
         master_npids
 
 
-def download_models(force_download=False):
+def download_models(force_download=False, include_sleepnet = True):
     """Download all required model files without processing any data."""
     import asleep.sslmodel as sslmodel
 
@@ -261,12 +261,13 @@ def download_models(force_download=False):
     # 3. asleep repo + SleepNet CNN-LSTM weights via torch.hub
     #    torch.hub.set_dir was set in step 2, so repo + weights land in torch_hub_cache/
     #    Parameters must match the pretrained weights (config_eval: cnn_lstm_eval + deployment)
-    print("Caching SleepNet repository and weights...")
-    torch.hub.load(
-        'OxWearables/asleep', 'sleepnet',
-        num_classes=5, lstm_nn_size=1024, lstm_layer=2,
-        dropout_p=0, bi_lstm=True,
-        trust_repo=True)
+    if include_sleepnet:
+        print("Caching SleepNet repository and weights...")
+        torch.hub.load(
+            'OxWearables/asleep', 'sleepnet',
+            num_classes=5, lstm_nn_size=1024, lstm_layer=2,
+            dropout_p=0, bi_lstm=True,
+            trust_repo=True)
 
     print("All models downloaded successfully.")
 

--- a/src/asleep/get_sleep.py
+++ b/src/asleep/get_sleep.py
@@ -189,7 +189,11 @@ def get_sleep_windows(data2model, times, non_wear, args):
             model_path, force_download=args.force_download)
         sleep_window_detector.device = args.pytorch_device  # expect channel last
         data_channel_last = np.swapaxes(data2model, 1, -1)
-        window_pred = sleep_window_detector.predict(data_channel_last)
+        num_workers = getattr(args, 'num_workers', 0)
+        if num_workers is None:
+            num_workers = 0
+        window_pred = sleep_window_detector.predict(
+            data_channel_last, num_workers=num_workers)
         sleep_prediction[~non_wear] = window_pred
         print(sleep_prediction.shape)
         print(np.unique(sleep_prediction, return_counts=True))
@@ -313,6 +317,11 @@ def main():
              "Default: 'mps' if available, otherwise 'cpu'",
         type=str,
         default=None)
+    parser.add_argument(
+        "--num_workers",
+        help="Number of worker processes to use for sleep window inference.",
+        type=int,
+        default=0)
     parser.add_argument(
         "--model_weight_path",
         "-w",

--- a/src/asleep/models.py
+++ b/src/asleep/models.py
@@ -103,7 +103,7 @@ class SleepWindowSSL:
         hmm_params = hmm_params or dict()
         self.hmms = hmm_utils.HMMSmoother(**hmm_params)
 
-    def fit(self, X, Y, groups=None):
+    def fit(self, X, Y, groups=None, num_workers=1):
         sslmodel.verbose = self.verbose
 
         if self.verbose:
@@ -137,14 +137,14 @@ class SleepWindowSSL:
             train_dataset,
             batch_size=self.batch_size,
             shuffle=True,
-            num_workers=1,
+            num_workers=num_workers,
         )
 
         val_loader = DataLoader(
             val_dataset,
             batch_size=self.batch_size,
             shuffle=False,
-            num_workers=1,
+            num_workers=num_workers,
         )
 
         class_weights = get_inverse_class_weights(y_train)
@@ -177,7 +177,7 @@ class SleepWindowSSL:
 
         return self
 
-    def predict(self, X, groups=None):
+    def predict(self, X, groups=None, num_workers=1):
         sslmodel.verbose = self.verbose
 
         dataset = sslmodel.NormalDataset(X, name='prediction')
@@ -185,7 +185,7 @@ class SleepWindowSSL:
             dataset,
             batch_size=self.batch_size,
             shuffle=False,
-            num_workers=1,
+            num_workers=num_workers,
         )
 
         model = sslmodel.get_sslnet(tag=self.repo_tag, pretrained=False)

--- a/src/asleep/models.py
+++ b/src/asleep/models.py
@@ -103,7 +103,7 @@ class SleepWindowSSL:
         hmm_params = hmm_params or dict()
         self.hmms = hmm_utils.HMMSmoother(**hmm_params)
 
-    def fit(self, X, Y, groups=None, num_workers=1):
+    def fit(self, X, Y, groups=None, num_workers=0):
         sslmodel.verbose = self.verbose
 
         if self.verbose:
@@ -177,7 +177,7 @@ class SleepWindowSSL:
 
         return self
 
-    def predict(self, X, groups=None, num_workers=1):
+    def predict(self, X, groups=None, num_workers=0):
         sslmodel.verbose = self.verbose
 
         dataset = sslmodel.NormalDataset(X, name='prediction')

--- a/src/asleep/train_capture24.py
+++ b/src/asleep/train_capture24.py
@@ -69,7 +69,7 @@ def main():
 
     sleep_window_detector = SleepWindowSSL(
         device=my_device, batch_size=2000, verbose=True)
-    sleep_window_detector.fit(X, y, groups=pid, num_workers = 1)
+    sleep_window_detector.fit(X, y, groups=pid, num_workers=1)
     joblib.dump(sleep_window_detector, 'ssl.joblib.lzma', compress=('lzma', 3))
 
 

--- a/src/asleep/train_capture24.py
+++ b/src/asleep/train_capture24.py
@@ -69,7 +69,7 @@ def main():
 
     sleep_window_detector = SleepWindowSSL(
         device=my_device, batch_size=2000, verbose=True)
-    sleep_window_detector.fit(X, y, groups=pid)
+    sleep_window_detector.fit(X, y, groups=pid, num_workers = 1)
     joblib.dump(sleep_window_detector, 'ssl.joblib.lzma', compress=('lzma', 3))
 
 


### PR DESCRIPTION
Since `get_sleep` is the main function rather than fitting, users can skip downloading the `asleep` repo to the torch cache.